### PR TITLE
fix: auto-detect DRM device with CRTCs, fix notify TTY

### DIFF
--- a/drm-colortemp-notify.sh
+++ b/drm-colortemp-notify.sh
@@ -20,10 +20,10 @@ fi
 
 # Detect DRM device (use same logic as main tool)
 DEVICE=""
-if [ -r "/dev/dri/card1" ]; then
-    DEVICE="/dev/dri/card1"
-elif [ -r "/dev/dri/card0" ]; then
+if [ -r "/dev/dri/card0" ]; then
     DEVICE="/dev/dri/card0"
+elif [ -r "/dev/dri/card1" ]; then
+    DEVICE="/dev/dri/card1"
 else
     # Search for first available card
     for i in {0..9}; do
@@ -55,11 +55,11 @@ for DISPLAY_NUM in 0 1; do
             if [ "$MODE" = "night" ]; then
                 ICON="weather-clear-night"
                 TITLE="🌙 Night Mode Ready"
-                MESSAGE="Press Ctrl+Alt+F3 then F2 to apply warm ${TEMP}K${DEVICE_MSG}"
+                MESSAGE="Press Ctrl+Alt+F3 then F1 to apply warm ${TEMP}K${DEVICE_MSG}"
             else
                 ICON="weather-clear"
                 TITLE="☀️ Day Mode Ready"  
-                MESSAGE="Press Ctrl+Alt+F3 then F2 to apply ${TEMP}K${DEVICE_MSG}"
+                MESSAGE="Press Ctrl+Alt+F3 then F1 to apply ${TEMP}K${DEVICE_MSG}"
             fi
             
             # Send notification as user
@@ -73,6 +73,6 @@ for DISPLAY_NUM in 0 1; do
 done
 
 # Fallback: try without specific DBUS (might work on some systems)
-su "$USERNAME" -c "notify-send -i 'weather-clear-night' -u normal -t 10000 'Color Temperature' 'Time to adjust: ${TEMP}K${DEVICE_MSG}. Press Ctrl+Alt+F3 then F2'" 2>/dev/null
+su "$USERNAME" -c "notify-send -i 'weather-clear-night' -u normal -t 10000 'Color Temperature' 'Time to adjust: ${TEMP}K${DEVICE_MSG}. Press Ctrl+Alt+F3 then F1'" 2>/dev/null
 
 exit 0

--- a/drm_device.c
+++ b/drm_device.c
@@ -7,61 +7,90 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <drm/drm.h>
+#include <drm/drm_mode.h>
 
 int drm_device_accessible(const char *device) {
     if (!device) {
         return 0;
     }
-    
+
     struct stat st;
     if (stat(device, &st) != 0) {
         return 0;
     }
-    
+
     // Check if it's a character device
     if (!S_ISCHR(st.st_mode)) {
         return 0;
     }
-    
+
     // Try to open it
     int fd = open(device, O_RDWR);
     if (fd < 0) {
         return 0;
     }
-    
+
     close(fd);
     return 1;
 }
 
+int drm_device_has_crtcs(const char *device) {
+    int fd = open(device, O_RDWR);
+    if (fd < 0) {
+        return 0;
+    }
+
+    struct drm_mode_card_res res = {0};
+    int ret = ioctl(fd, DRM_IOCTL_MODE_GETRESOURCES, &res);
+    close(fd);
+
+    return (ret == 0 && res.count_crtcs > 0);
+}
+
 int drm_find_device(char *device_out, size_t device_out_size) {
-    // Try card0 through card9
+    // Try card0 through card9, pick the first with CRTCs
     for (int i = 0; i < 10; i++) {
         char device[64];
         snprintf(device, sizeof(device), "/dev/dri/card%d", i);
-        
+
+        if (drm_device_has_crtcs(device)) {
+            snprintf(device_out, device_out_size, "%s", device);
+            return 0;
+        }
+    }
+
+    // Fallback: first accessible device (even without CRTCs)
+    for (int i = 0; i < 10; i++) {
+        char device[64];
+        snprintf(device, sizeof(device), "/dev/dri/card%d", i);
+
         if (drm_device_accessible(device)) {
             snprintf(device_out, device_out_size, "%s", device);
             return 0;
         }
     }
-    
+
     return -1;
 }
 
 int drm_open_device(const char *preferred_device, char *device_out, size_t device_out_size) {
     int fd = -1;
     char actual_device[256] = {0};
-    
-    // Try preferred device first
+
+    // Try preferred device first, but only if it has CRTCs
     if (preferred_device && preferred_device[0] != '\0') {
-        fd = open(preferred_device, O_RDWR);
-        if (fd >= 0) {
-            snprintf(actual_device, sizeof(actual_device), "%s", preferred_device);
+        if (drm_device_has_crtcs(preferred_device)) {
+            fd = open(preferred_device, O_RDWR);
+            if (fd >= 0) {
+                snprintf(actual_device, sizeof(actual_device), "%s", preferred_device);
+            }
         }
     }
-    
-    // If that failed, search for available device
+
+    // If preferred device had no CRTCs or failed, auto-detect
     if (fd < 0) {
         char found_device[256];
         if (drm_find_device(found_device, sizeof(found_device)) == 0) {
@@ -71,11 +100,11 @@ int drm_open_device(const char *preferred_device, char *device_out, size_t devic
             }
         }
     }
-    
+
     // Store the device path we actually used
     if (fd >= 0 && device_out) {
         snprintf(device_out, device_out_size, "%s", actual_device);
     }
-    
+
     return fd;
 }

--- a/drm_device.h
+++ b/drm_device.h
@@ -24,11 +24,22 @@ int drm_open_device(const char *preferred_device, char *device_out, size_t devic
 
 /**
  * Check if a DRM device exists and is accessible
- * 
+ *
  * @param device Device path to check
  * @return 1 if accessible, 0 otherwise
  */
 int drm_device_accessible(const char *device);
+
+/**
+ * Check if a DRM device has CRTCs (display outputs)
+ *
+ * Some GPUs (e.g. NVIDIA with proprietary driver) may be accessible
+ * but expose no CRTCs via the legacy DRM API.
+ *
+ * @param device Device path to check
+ * @return 1 if device has CRTCs, 0 otherwise
+ */
+int drm_device_has_crtcs(const char *device);
 
 /**
  * Find first available DRM card device


### PR DESCRIPTION
## Summary

- Auto-detect the correct DRM device by checking for CRTCs instead of relying on a fixed card number. On multi-GPU systems (Intel + NVIDIA), `/dev/dri/card*` numbering can change between boots or when monitors are connected, causing `No CRTCs found` errors.
- Fix notification script to say "F1" instead of "F2" (COSMIC runs on TTY1) and prefer card0 over card1 in device detection.

See #3 for details.

## Changes

### `drm_device.c` / `drm_device.h`
- Add `drm_device_has_crtcs()` — checks if a device exposes CRTCs via legacy DRM API
- `drm_find_device()` now picks the first card with CRTCs, with fallback to first accessible card
- `drm_open_device()` skips the preferred device if it has no CRTCs and auto-detects instead

### `drm-colortemp-notify.sh`
- Fix "F2" → "F1" in all notification messages
- Swap card detection order (card0 before card1)

## Test plan

- [x] Tested on Pop!_OS 24.04 with Intel i915 + NVIDIA dual-GPU laptop
- [x] Verified auto-detection picks the correct card regardless of numbering
- [x] Confirmed gamma applies successfully to both single and dual monitor setups