### PR TITLE
fix: always reapply gamma on TTY switch

### DIFF
--- a/drm_colortemp_daemon_inotify.c
+++ b/drm_colortemp_daemon_inotify.c
@@ -452,7 +452,7 @@ void daemon_loop(const char *config_file) {
                         config.cool_tty, target_temp);
             }
 
-            if (target_temp > 0 && (target_temp != last_applied_temp || last_applied_temp == 0)) {
+            if (target_temp > 0) {
                 log_msg("INFO", "Applying temperature: %dK", target_temp);
 
                 if (apply_temperature(target_temp) == 0) {


### PR DESCRIPTION
## Summary

- Always reapply gamma when the user switches to a monitored TTY, even if the target temperature hasn't changed.

## Problem

The daemon skips applying when the target temperature matches the last applied value. But the compositor resets gamma tables whenever the monitor configuration changes (docking/undocking, switching between single and dual monitors). The daemon has no way to detect this reset, so it silently stops working until the next temperature *change* (e.g. sunrise/sunset).

## Fix

Remove the `target_temp != last_applied_temp` guard on TTY switch. The TTY switch is an explicit user action, so it should always apply.

## Test plan

- [x] Tested on Pop!_OS 24.04 COSMIC with Intel + NVIDIA dual-GPU
- [x] Verified gamma reapplies after undocking/redocking with the same temperature