### PR TITLE
fix: add multi-card support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,21 @@ $(TOOL): $(TOOL_OBJ)
 $(DAEMON): $(DAEMON_OBJ)
 	$(CC) $(CFLAGS) $(DAEMON_OBJ) -o $(DAEMON) $(LIBS)
 
+# Test binary
+TEST = test_config
+TEST_DAEMON_OBJ = drm_colortemp_daemon_inotify_test.o
+
+$(TEST): test_config.c $(TEST_DAEMON_OBJ) drm_colortemp_utils.o drm_device.o
+	$(CC) $(CFLAGS) -DTEST_BUILD $^ -o $@ $(LIBS)
+
+drm_colortemp_daemon_inotify_test.o: drm_colortemp_daemon_inotify.c drm_device.h drm_colortemp_utils.h
+	$(CC) $(CFLAGS) -DTEST_BUILD -c $< -o $@
+
+test: $(TEST)
+	./$(TEST)
+
 clean:
-	rm -f $(TOOL) $(DAEMON) *.o
+	rm -f $(TOOL) $(DAEMON) $(TEST) *.o
 	rm -rf build-deb
 
 # Debian package

--- a/drm-colortemp.conf
+++ b/drm-colortemp.conf
@@ -2,7 +2,13 @@
 # Configuration for DRM Color Temperature Daemon
 
 # DRM device to use
+# For a single card setup use DEVICE:
 DEVICE="/dev/dri/card1"
+# For multi-card setups use DEVICE1, DEVICE2, ... (up to DEVICE8).
+# When any DEVICEn key is present it takes precedence for that slot.
+# Example:
+# DEVICE1="/dev/dri/card0"
+# DEVICE2="/dev/dri/card1"
 
 # Day temperature in Kelvin (1000-10000)
 DAY_TEMP=6500

--- a/drm_colortemp_daemon_inotify.c
+++ b/drm_colortemp_daemon_inotify.c
@@ -29,10 +29,12 @@
 
 #define CONFIG_FILE "/etc/default/drm-colortemp.conf"
 #define MAX_LINE 256
+#define MAX_DEVICES 8
 
 // Configuration
 typedef struct {
-    char device[256];
+    char devices[MAX_DEVICES][256];
+    int num_devices;
     int day_temp;
     int night_temp;
     int sunset_hour;
@@ -50,7 +52,7 @@ typedef struct {
 // Global state
 static volatile int running = 1;
 static volatile int reload_config = 0;
-static config_t config;
+config_t config;
 
 // Signal handler
 void signal_handler(int signum) {
@@ -111,7 +113,8 @@ int load_config(const char *filename) {
     }
     
     // Set defaults
-    strncpy(config.device, "/dev/dri/card1", sizeof(config.device) - 1);
+    memset(config.devices, 0, sizeof(config.devices));
+    config.num_devices = 0;
     config.day_temp = 6500;
     config.night_temp = 3500;
     config.sunset_hour = 20;
@@ -147,7 +150,12 @@ int load_config(const char *filename) {
         value = remove_quotes(value);
         
         if (strcmp(key, "DEVICE") == 0) {
-            strncpy(config.device, value, sizeof(config.device) - 1);
+            strncpy(config.devices[0], value, sizeof(config.devices[0]) - 1);
+            if (config.num_devices < 1) config.num_devices = 1;
+        } else if (strncmp(key, "DEVICE", 6) == 0 && key[6] >= '1' && key[6] <= '0' + MAX_DEVICES && key[7] == '\0') {
+            int idx = key[6] - '1';
+            strncpy(config.devices[idx], value, sizeof(config.devices[idx]) - 1);
+            if (config.num_devices < idx + 1) config.num_devices = idx + 1;
         } else if (strcmp(key, "DAY_TEMP") == 0) {
             config.day_temp = atoi(value);
         } else if (strcmp(key, "NIGHT_TEMP") == 0) {
@@ -176,10 +184,26 @@ int load_config(const char *filename) {
     }
     
     fclose(f);
-    
+
+    // Auto-detect devices if none explicitly configured
+    if (config.num_devices == 0) {
+        int found = drm_find_all_devices(config.devices, MAX_DEVICES);
+        if (found > 0) {
+            config.num_devices = found;
+            log_msg("INFO", "Auto-detected %d DRM device(s)", found);
+        } else {
+            // Last-resort fallback: use first accessible device
+            if (drm_find_device(config.devices[0], sizeof(config.devices[0])) == 0) {
+                config.num_devices = 1;
+            }
+        }
+    }
+
     log_msg("INFO", "Configuration loaded from %s", filename);
     if (config.verbose) {
-        log_msg("INFO", "Device: %s", config.device);
+        for (int i = 0; i < config.num_devices; i++) {
+            log_msg("INFO", "Device[%d]: %s", i, config.devices[i]);
+        }
         log_msg("INFO", "Day temp: %dK, Night temp: %dK", config.day_temp, config.night_temp);
         log_msg("INFO", "Sunset: %02d:00, Sunrise: %02d:00", config.sunset_hour, config.sunrise_hour);
         log_msg("INFO", "Monitor TTY: %d, Warm TTY: %d, Cool TTY: %d",
@@ -277,87 +301,85 @@ int get_crtc_info(int fd, uint32_t crtc_id, int *gamma_size, int *mode_valid) {
     return 0;
 }
 
-// Apply temperature to all displays
-int apply_temperature(int temp) {
-    char actual_device[256];
-    int fd = drm_open_device(config.device, actual_device, sizeof(actual_device));
-    if (fd < 0) {
-        log_msg("ERROR", "Failed to open DRM device: %s", strerror(errno));
-        return -1;
-    }
-    if (config.verbose && strcmp(actual_device, config.device) != 0) {
-        log_msg("INFO", "Using device %s", actual_device);
-    }
-    
-    // Get resources
+// Apply temperature to all CRTCs on a single DRM device fd
+static int apply_temperature_to_fd(int fd, const char *device_name, int temp) {
     struct drm_mode_card_res res = {0};
     if (ioctl(fd, DRM_IOCTL_MODE_GETRESOURCES, &res) < 0) {
-        log_msg("ERROR", "Failed to get DRM resources");
-        close(fd);
+        log_msg("ERROR", "Failed to get DRM resources for %s", device_name);
         return -1;
     }
-    
+
     if (res.count_crtcs == 0) {
-        log_msg("ERROR", "No CRTCs found");
-        close(fd);
+        log_msg("ERROR", "No CRTCs found on %s", device_name);
         return -1;
     }
-    
-    // Allocate arrays
+
     uint32_t *crtcs = calloc(res.count_crtcs, sizeof(uint32_t));
     uint32_t *fbs = calloc(res.count_fbs, sizeof(uint32_t));
     uint32_t *connectors = calloc(res.count_connectors, sizeof(uint32_t));
     uint32_t *encoders = calloc(res.count_encoders, sizeof(uint32_t));
-    
+
     if (!crtcs) {
-        close(fd);
+        free(fbs); free(connectors); free(encoders);
         return -1;
     }
-    
+
     res.fb_id_ptr = (uint64_t)(uintptr_t)fbs;
     res.crtc_id_ptr = (uint64_t)(uintptr_t)crtcs;
     res.connector_id_ptr = (uint64_t)(uintptr_t)connectors;
     res.encoder_id_ptr = (uint64_t)(uintptr_t)encoders;
-    
+
     if (ioctl(fd, DRM_IOCTL_MODE_GETRESOURCES, &res) < 0) {
-        log_msg("ERROR", "Failed to get CRTC list");
-        free(crtcs);
-        free(fbs);
-        free(connectors);
-        free(encoders);
-        close(fd);
+        log_msg("ERROR", "Failed to get CRTC list for %s", device_name);
+        free(crtcs); free(fbs); free(connectors); free(encoders);
         return -1;
     }
-    
+
     int success_count = 0;
-    
+
     for (uint32_t i = 0; i < res.count_crtcs; i++) {
         uint32_t crtc_id = crtcs[i];
         int gamma_size, mode_valid;
-        
-        if (get_crtc_info(fd, crtc_id, &gamma_size, &mode_valid) < 0) {
+
+        if (get_crtc_info(fd, crtc_id, &gamma_size, &mode_valid) < 0)
             continue;
-        }
-        
-        if (!mode_valid || gamma_size == 0) {
+        if (!mode_valid || gamma_size == 0)
             continue;
-        }
-        
+
         if (set_gamma_temp(fd, crtc_id, gamma_size, temp) == 0) {
             success_count++;
             if (config.verbose) {
-                log_msg("INFO", "Applied %dK to CRTC %u", temp, crtc_id);
+                log_msg("INFO", "Applied %dK to %s CRTC %u", temp, device_name, crtc_id);
             }
         }
     }
-    
-    free(crtcs);
-    free(fbs);
-    free(connectors);
-    free(encoders);
-    close(fd);
-    
+
+    free(crtcs); free(fbs); free(connectors); free(encoders);
     return success_count > 0 ? 0 : -1;
+}
+
+// Apply temperature to all displays on all configured devices
+int apply_temperature(int temp) {
+    int total_success = 0;
+
+    for (int d = 0; d < config.num_devices; d++) {
+        char actual_device[256];
+        int fd = drm_open_device(config.devices[d], actual_device, sizeof(actual_device));
+        if (fd < 0) {
+            log_msg("ERROR", "Failed to open DRM device %s: %s", config.devices[d], strerror(errno));
+            continue;
+        }
+        if (config.verbose && strcmp(actual_device, config.devices[d]) != 0) {
+            log_msg("INFO", "Using device %s (requested %s)", actual_device, config.devices[d]);
+        }
+
+        if (apply_temperature_to_fd(fd, actual_device, temp) == 0)
+            total_success++;
+
+        close(fd);
+    }
+
+    return total_success > 0 ? 0 : -1;
 }
 
 // Main daemon loop with inotify
@@ -506,6 +528,7 @@ void print_usage(const char *prog) {
     printf("Edit %s and changes apply automatically.\n", CONFIG_FILE);
 }
 
+#ifndef TEST_BUILD
 int main(int argc, char *argv[]) {
     const char *config_file = CONFIG_FILE;
     int opt;
@@ -543,6 +566,7 @@ int main(int argc, char *argv[]) {
     
     // Run daemon
     daemon_loop(config_file);
-    
+
     return 0;
 }
+#endif /* TEST_BUILD */

--- a/drm_device.c
+++ b/drm_device.c
@@ -76,6 +76,19 @@ int drm_find_device(char *device_out, size_t device_out_size) {
     return -1;
 }
 
+int drm_find_all_devices(char (*devices)[256], int max_devices) {
+    int count = 0;
+    for (int i = 0; i < 10 && count < max_devices; i++) {
+        char device[64];
+        snprintf(device, sizeof(device), "/dev/dri/card%d", i);
+        if (drm_device_has_crtcs(device)) {
+            snprintf(devices[count], 256, "%s", device);
+            count++;
+        }
+    }
+    return count;
+}
+
 int drm_open_device(const char *preferred_device, char *device_out, size_t device_out_size) {
     int fd = -1;
     char actual_device[256] = {0};

--- a/drm_device.h
+++ b/drm_device.h
@@ -43,11 +43,23 @@ int drm_device_has_crtcs(const char *device);
 
 /**
  * Find first available DRM card device
- * 
+ *
  * @param device_out Buffer to store device path (min 256 bytes)
  * @param device_out_size Size of device_out buffer
  * @return 0 on success, -1 if no device found
  */
 int drm_find_device(char *device_out, size_t device_out_size);
+
+/**
+ * Find all DRM card devices that have CRTCs
+ *
+ * Scans /dev/dri/card0 through card9 and collects every device
+ * that has at least one CRTC (i.e. can drive a display).
+ *
+ * @param devices  Array of device path buffers, each 256 bytes
+ * @param max_devices Maximum number of devices to return
+ * @return Number of devices found (0 if none)
+ */
+int drm_find_all_devices(char (*devices)[256], int max_devices);
 
 #endif /* DRM_DEVICE_H */

--- a/test_config.c
+++ b/test_config.c
@@ -1,0 +1,212 @@
+/*
+ * test_config.c - Unit tests for config parsing (multi-device support)
+ *
+ * Compiled with TEST_BUILD so the daemon's main() is excluded.
+ * Links against drm_colortemp_daemon_inotify.o to test load_config() directly.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define MAX_LINE 256
+#define MAX_DEVICES 8
+
+/* Mirrors config_t from daemon - must stay in sync */
+typedef struct {
+    char devices[MAX_DEVICES][256];
+    int num_devices;
+    int day_temp;
+    int night_temp;
+    int sunset_hour;
+    int sunrise_hour;
+    int monitor_tty;
+    int warm_tty;
+    int cool_tty;
+    int check_interval;
+    int verbose;
+    double latitude;
+    double longitude;
+    int has_location;
+} config_t;
+
+/* Defined in drm_colortemp_daemon_inotify.o */
+extern config_t config;
+extern int load_config(const char *filename);
+
+/* ---------- helpers ---------- */
+
+static int pass_count = 0;
+static int fail_count = 0;
+
+#define ASSERT(cond, msg) do { \
+    if (cond) { \
+        printf("  PASS: %s\n", msg); \
+        pass_count++; \
+    } else { \
+        printf("  FAIL: %s  (line %d)\n", msg, __LINE__); \
+        fail_count++; \
+    } \
+} while (0)
+
+/* Write a temp conf file, return path (caller must unlink) */
+static char *write_conf(const char *content) {
+    char *path = strdup("/tmp/test_drm_colortemp_XXXXXX.conf");
+    int fd = mkstemps(path, 5);
+    if (fd < 0) { perror("mkstemps"); exit(1); }
+    write(fd, content, strlen(content));
+    close(fd);
+    return path;
+}
+
+/* ---------- tests ---------- */
+
+static void test_single_device_legacy(void) {
+    printf("test: DEVICE= (legacy single-device)\n");
+    char *path = write_conf("DEVICE=\"/dev/dri/card0\"\n");
+    load_config(path);
+    unlink(path); free(path);
+
+    ASSERT(config.num_devices == 1, "num_devices == 1");
+    ASSERT(strcmp(config.devices[0], "/dev/dri/card0") == 0, "devices[0] == /dev/dri/card0");
+}
+
+static void test_device1_device2(void) {
+    printf("test: DEVICE1= + DEVICE2= (multi-device)\n");
+    char *path = write_conf(
+        "DEVICE1=\"/dev/dri/card0\"\n"
+        "DEVICE2=\"/dev/dri/card1\"\n"
+    );
+    load_config(path);
+    unlink(path); free(path);
+
+    ASSERT(config.num_devices == 2, "num_devices == 2");
+    ASSERT(strcmp(config.devices[0], "/dev/dri/card0") == 0, "devices[0] == /dev/dri/card0");
+    ASSERT(strcmp(config.devices[1], "/dev/dri/card1") == 0, "devices[1] == /dev/dri/card1");
+}
+
+static void test_mixed_device_and_device2(void) {
+    printf("test: DEVICE= + DEVICE2= (mixed)\n");
+    char *path = write_conf(
+        "DEVICE=\"/dev/dri/card0\"\n"
+        "DEVICE2=\"/dev/dri/card1\"\n"
+    );
+    load_config(path);
+    unlink(path); free(path);
+
+    ASSERT(config.num_devices == 2, "num_devices == 2");
+    ASSERT(strcmp(config.devices[0], "/dev/dri/card0") == 0, "devices[0] == /dev/dri/card0");
+    ASSERT(strcmp(config.devices[1], "/dev/dri/card1") == 0, "devices[1] == /dev/dri/card1");
+}
+
+static void test_device_max(void) {
+    printf("test: DEVICE1..DEVICE8 (max devices)\n");
+    char *path = write_conf(
+        "DEVICE1=\"/dev/dri/card0\"\n"
+        "DEVICE2=\"/dev/dri/card1\"\n"
+        "DEVICE3=\"/dev/dri/card2\"\n"
+        "DEVICE4=\"/dev/dri/card3\"\n"
+        "DEVICE5=\"/dev/dri/card4\"\n"
+        "DEVICE6=\"/dev/dri/card5\"\n"
+        "DEVICE7=\"/dev/dri/card6\"\n"
+        "DEVICE8=\"/dev/dri/card7\"\n"
+    );
+    load_config(path);
+    unlink(path); free(path);
+
+    ASSERT(config.num_devices == 8, "num_devices == 8");
+    ASSERT(strcmp(config.devices[7], "/dev/dri/card7") == 0, "devices[7] == /dev/dri/card7");
+}
+
+static void test_no_device_autodetect(void) {
+    printf("test: no DEVICE= (auto-detect)\n");
+    char *path = write_conf("DAY_TEMP=6500\n");
+    load_config(path);
+    unlink(path); free(path);
+
+    /* Auto-detect may find 0 or more devices depending on hardware.
+     * We just verify the function handled it without crashing and
+     * num_devices is non-negative. */
+    ASSERT(config.num_devices >= 0, "num_devices >= 0 (no crash)");
+    printf("  INFO: auto-detected %d device(s)\n", config.num_devices);
+}
+
+static void test_single_values_parsed(void) {
+    printf("test: scalar config values\n");
+    char *path = write_conf(
+        "DEVICE=\"/dev/dri/card0\"\n"
+        "DAY_TEMP=5500\n"
+        "NIGHT_TEMP=2700\n"
+        "SUNSET_HOUR=19\n"
+        "SUNRISE_HOUR=7\n"
+        "MONITOR_TTY=3\n"
+        "WARM_TTY=4\n"
+        "COOL_TTY=5\n"
+        "CHECK_INTERVAL=2\n"
+        "VERBOSE=1\n"
+        "LOCATION=\"51.5074,-0.1278\"\n"
+    );
+    load_config(path);
+    unlink(path); free(path);
+
+    ASSERT(config.day_temp == 5500,   "day_temp == 5500");
+    ASSERT(config.night_temp == 2700, "night_temp == 2700");
+    ASSERT(config.sunset_hour == 19,  "sunset_hour == 19");
+    ASSERT(config.sunrise_hour == 7,  "sunrise_hour == 7");
+    ASSERT(config.monitor_tty == 3,   "monitor_tty == 3");
+    ASSERT(config.warm_tty == 4,      "warm_tty == 4");
+    ASSERT(config.cool_tty == 5,      "cool_tty == 5");
+    ASSERT(config.check_interval == 2,"check_interval == 2");
+    ASSERT(config.verbose == 1,       "verbose == 1");
+    ASSERT(config.has_location == 1,  "has_location == 1");
+}
+
+static void test_comments_and_empty_lines(void) {
+    printf("test: comments and empty lines ignored\n");
+    char *path = write_conf(
+        "# This is a comment\n"
+        "\n"
+        "   # Indented comment\n"
+        "DEVICE=\"/dev/dri/card0\"\n"
+        "\n"
+        "DAY_TEMP=4000\n"
+    );
+    load_config(path);
+    unlink(path); free(path);
+
+    ASSERT(config.num_devices == 1, "num_devices == 1");
+    ASSERT(config.day_temp == 4000,  "day_temp == 4000");
+}
+
+static void test_device_out_of_range_ignored(void) {
+    printf("test: DEVICE0 and DEVICE9 are ignored (out of range)\n");
+    char *path = write_conf(
+        "DEVICE1=\"/dev/dri/card0\"\n"
+        "DEVICE9=\"/dev/dri/card9\"\n"  /* >MAX_DEVICES, should be ignored */
+    );
+    load_config(path);
+    unlink(path); free(path);
+
+    /* DEVICE9 is > MAX_DEVICES=8, so only DEVICE1 should be stored */
+    ASSERT(config.num_devices == 1, "num_devices == 1 (DEVICE9 ignored)");
+    ASSERT(strcmp(config.devices[0], "/dev/dri/card0") == 0, "devices[0] == /dev/dri/card0");
+}
+
+/* ---------- main ---------- */
+
+int main(void) {
+    printf("=== drm-colortemp config unit tests ===\n\n");
+
+    test_single_device_legacy();
+    test_device1_device2();
+    test_mixed_device_and_device2();
+    test_device_max();
+    test_no_device_autodetect();
+    test_single_values_parsed();
+    test_comments_and_empty_lines();
+    test_device_out_of_range_ignored();
+
+    printf("\n=== Results: %d passed, %d failed ===\n", pass_count, fail_count);
+    return fail_count > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #6.

## What

Adds multi-card support to the daemon (`drm_colortemp_daemon_inotify.c`, `drm_device.c`/`.h`), a unit test suite (`test_config.c`), and documentation updates (`README.md`, `drm-colortemp.conf`).


## Why

Users with displays driven by multiple GPUs had no way to apply color temperature to all cards at once — the config only accepted a single `DEVICE` path.

- `config_t.device` replaced with `devices[MAX_DEVICES][256]` + `num_devices`; `MAX_DEVICES` is 8
- `load_config()` parses `DEVICE` (backward-compatible, maps to slot 0) and `DEVICE1`–`DEVICE8`; when no device key is present, calls `drm_find_all_devices()` to auto-detect all cards with CRTCs
- `drm_find_all_devices()` added to `drm_device.c`/`.h`: scans `card0`–`card9`, returns all with CRTCs
- `apply_temperature()` refactored into a per-fd helper and an outer loop over all configured devices
- `main()` wrapped in `#ifndef TEST_BUILD` to allow linking the daemon object into tests without a duplicate `main`
- `test_config.c` added: 8 test cases / 25 assertions covering legacy `DEVICE=`, `DEVICE1`+`DEVICE2`, mixed, max 8 devices, auto-detect, scalar values, comment handling, and out-of-range keys
- `make test` target added; CI (`build.yml`) runs it after build; `check.yml` also compiles with `-DTEST_BUILD`

## Result

- single-card users: no config change needed — existing `DEVICE=` still works
- multi-card users: set `DEVICE1=`, `DEVICE2=`, … or omit `DEVICE` entirely to auto-detect all cards with CRTCs
- `make test` runs 25 unit tests locally and in CI

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
