### PR TITLE
packaging/aur: AUR templates for 0.2.10

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,17 @@
+pkgbase = drm-colortemp
+	pkgdesc = DRM color temperature control for COSMIC DE (wlr-gamma-control workaround)
+	pkgver = 0.2.10
+	pkgrel = 1
+	url = https://github.com/jjo/drm-colortemp
+	arch = x86_64
+	license = Apache-2.0
+	makedepends = gcc
+	makedepends = pkgconf
+	makedepends = make
+	depends = libdrm
+	optdepends = libnotify: desktop notifications
+	backup = etc/default/drm-colortemp.conf
+	source = drm-colortemp-0.2.10.tar.gz::https://github.com/jjo/drm-colortemp/archive/refs/tags/v0.2.10.tar.gz
+	sha256sums = c7da86b2bc5fa7ab50968d5c44c502850885cb30900b8700242ea5ce76ff4fde
+
+pkgname = drm-colortemp

--- a/packaging/aur/.SRCINFO-git
+++ b/packaging/aur/.SRCINFO-git
@@ -1,0 +1,20 @@
+pkgbase = drm-colortemp-git
+	pkgdesc = DRM color temperature control for COSMIC DE (git version)
+	pkgver = 0.2.10.r0.g0000000
+	pkgrel = 1
+	url = https://github.com/jjo/drm-colortemp
+	arch = x86_64
+	license = Apache-2.0
+	makedepends = gcc
+	makedepends = pkgconf
+	makedepends = make
+	makedepends = git
+	depends = libdrm
+	optdepends = libnotify: desktop notifications
+	provides = drm-colortemp=0.2.10.r0.g0000000
+	conflicts = drm-colortemp
+	backup = etc/default/drm-colortemp.conf
+	source = drm-colortemp::git+https://github.com/jjo/drm-colortemp.git
+	sha256sums = SKIP
+
+pkgname = drm-colortemp-git

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: JuanJo Ciarlante <jjo@users.noreply.github.com>
+pkgname=drm-colortemp
+pkgver=0.2.10
+pkgrel=1
+pkgdesc="DRM color temperature control for COSMIC DE (wlr-gamma-control workaround)"
+arch=('x86_64')
+url="https://github.com/jjo/drm-colortemp"
+license=('Apache-2.0')
+depends=('libdrm')
+optdepends=('libnotify: desktop notifications')
+makedepends=('gcc' 'pkgconf' 'make')
+backup=('etc/default/drm-colortemp.conf')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/jjo/drm-colortemp/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('c7da86b2bc5fa7ab50968d5c44c502850885cb30900b8700242ea5ce76ff4fde')
+
+build() {
+  cd "$pkgname-$pkgver"
+  make
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+  make test
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  install -Dm755 drm_colortemp              "$pkgdir/usr/bin/drm_colortemp"
+  install -Dm755 drm_colortemp_daemon       "$pkgdir/usr/bin/drm_colortemp_daemon"
+  install -Dm755 drm-colortemp-notify.sh    "$pkgdir/usr/bin/drm-colortemp-notify.sh"
+  install -Dm755 drm-colortemp-notifier.sh  "$pkgdir/usr/bin/drm-colortemp-notifier.sh"
+
+  install -Dm644 drm-colortemp.conf "$pkgdir/etc/default/drm-colortemp.conf"
+
+  install -Dm644 drm-colortemp-daemon.service   "$pkgdir/usr/lib/systemd/system/drm-colortemp-daemon.service"
+  install -Dm644 drm-colortemp-notifier.service "$pkgdir/usr/lib/systemd/system/drm-colortemp-notifier.service"
+
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+  install -Dm644 LICENSE   "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  # Source defaults to /usr/local/bin paths; rewrite for distro install layout
+  sed -i 's|/usr/local/bin|/usr/bin|g' \
+    "$pkgdir/usr/lib/systemd/system/drm-colortemp-daemon.service" \
+    "$pkgdir/usr/lib/systemd/system/drm-colortemp-notifier.service" \
+    "$pkgdir/usr/bin/drm-colortemp-notifier.sh"
+}

--- a/packaging/aur/PKGBUILD-git
+++ b/packaging/aur/PKGBUILD-git
@@ -1,0 +1,56 @@
+# Maintainer: JuanJo Ciarlante <jjo@users.noreply.github.com>
+pkgname=drm-colortemp-git
+_pkgname=drm-colortemp
+pkgver=0.2.10.r0.g0000000
+pkgrel=1
+pkgdesc="DRM color temperature control for COSMIC DE (git version)"
+arch=('x86_64')
+url="https://github.com/jjo/drm-colortemp"
+license=('Apache-2.0')
+depends=('libdrm')
+optdepends=('libnotify: desktop notifications')
+makedepends=('gcc' 'pkgconf' 'make' 'git')
+provides=("$_pkgname=$pkgver")
+conflicts=("$_pkgname")
+backup=('etc/default/drm-colortemp.conf')
+source=("$_pkgname::git+https://github.com/jjo/drm-colortemp.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$_pkgname"
+  git describe --long --tags --abbrev=7 2>/dev/null \
+    | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g' \
+    || printf "0.0.0.r%s.g%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+}
+
+build() {
+  cd "$_pkgname"
+  make
+}
+
+check() {
+  cd "$_pkgname"
+  make test
+}
+
+package() {
+  cd "$_pkgname"
+
+  install -Dm755 drm_colortemp              "$pkgdir/usr/bin/drm_colortemp"
+  install -Dm755 drm_colortemp_daemon       "$pkgdir/usr/bin/drm_colortemp_daemon"
+  install -Dm755 drm-colortemp-notify.sh    "$pkgdir/usr/bin/drm-colortemp-notify.sh"
+  install -Dm755 drm-colortemp-notifier.sh  "$pkgdir/usr/bin/drm-colortemp-notifier.sh"
+
+  install -Dm644 drm-colortemp.conf "$pkgdir/etc/default/drm-colortemp.conf"
+
+  install -Dm644 drm-colortemp-daemon.service   "$pkgdir/usr/lib/systemd/system/drm-colortemp-daemon.service"
+  install -Dm644 drm-colortemp-notifier.service "$pkgdir/usr/lib/systemd/system/drm-colortemp-notifier.service"
+
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$_pkgname/README.md"
+  install -Dm644 LICENSE   "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
+
+  sed -i 's|/usr/local/bin|/usr/bin|g' \
+    "$pkgdir/usr/lib/systemd/system/drm-colortemp-daemon.service" \
+    "$pkgdir/usr/lib/systemd/system/drm-colortemp-notifier.service" \
+    "$pkgdir/usr/bin/drm-colortemp-notifier.sh"
+}

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,61 @@
+# AUR packaging
+
+Two `PKGBUILD`s for Arch User Repository:
+
+- `PKGBUILD`     — versioned package `drm-colortemp` (release tag tarball)
+- `PKGBUILD-git` — VCS package `drm-colortemp-git` (tracks `main`)
+
+These are templates kept in the upstream tree. The AUR itself requires a
+**separate git repo per package** under `ssh://aur@aur.archlinux.org/`. Do not
+push this directory there directly — copy the relevant `PKGBUILD` into the AUR
+repo as `PKGBUILD`, generate `.SRCINFO`, then push.
+
+## Prerequisites
+
+- AUR account with SSH key uploaded: <https://aur.archlinux.org/account/>
+- `base-devel`, `pacman-contrib` (for `updpkgsums`), `namcap`
+
+## Local verification (always run before pushing)
+
+```bash
+cd packaging/aur
+cp PKGBUILD /tmp/aur-test/PKGBUILD       # work in a scratch dir
+cd /tmp/aur-test
+updpkgsums                                # refresh sha256
+makepkg -si                               # build + install — must succeed clean
+namcap PKGBUILD
+namcap drm-colortemp-*.pkg.tar.zst
+makepkg --printsrcinfo > .SRCINFO
+```
+
+## Publishing the versioned package
+
+```bash
+git clone ssh://aur@aur.archlinux.org/drm-colortemp.git aur-drm-colortemp
+cp packaging/aur/PKGBUILD aur-drm-colortemp/PKGBUILD
+cd aur-drm-colortemp
+makepkg --printsrcinfo > .SRCINFO
+git add PKGBUILD .SRCINFO
+git commit -m "drm-colortemp 0.2.10-1: initial import"
+git push origin master
+```
+
+## Publishing the `-git` package
+
+```bash
+git clone ssh://aur@aur.archlinux.org/drm-colortemp-git.git aur-drm-colortemp-git
+cp packaging/aur/PKGBUILD-git aur-drm-colortemp-git/PKGBUILD
+cd aur-drm-colortemp-git
+makepkg --printsrcinfo > .SRCINFO
+git add PKGBUILD .SRCINFO
+git commit -m "drm-colortemp-git: initial import"
+git push origin master
+```
+
+## Updating on new release
+
+1. Bump `pkgver` in `packaging/aur/PKGBUILD`, set `pkgrel=1`.
+2. `updpkgsums` to refresh the tarball checksum.
+3. Sync to the AUR repo, regen `.SRCINFO`, commit, push.
+
+The `-git` package needs no version bump — `pkgver()` resolves at build time.


### PR DESCRIPTION
- PKGBUILD/.SRCINFO: pkgver=0.2.10, sha256 for v0.2.10.tar.gz
- PKGBUILD-git/.SRCINFO-git: pkgver=0.2.10.r0.g0000000
- README: AUR publishing workflow + example commit
