### PR TITLE
fix: systemd DeviceAllow blocking non-card0 GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ section heading format strict: `## [X.Y.Z] - YYYY-MM-DD`.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-21
+
+### Fixed
+- Systemd unit (`scripts/drm-colortemp.service`) used
+  `DeviceAllow=/dev/dri/card0 rw`, which blocked the daemon's cgroup
+  device filter from opening any other DRM node. On machines where the
+  active GPU isn't `card0` (e.g. ThinkPad T480s: `card0`/`card2` are
+  EVDI virtual cards, `card1` is the real Intel iGPU), auto-detect fell
+  back to a virtual card whose CRTCs report `mode_valid=0`, and gamma
+  application failed silently with `no CRTCs accepted the gamma change`.
+  Replaced with `DeviceAllow=char-drm rw` to cover every `/dev/dri/*`.
+- Service `ExecStart` aligned with the `.deb` install path (`/usr/bin`).
+- Added `DeviceAllow` entries for `/dev/tty0` and `/dev/console`, needed
+  by `VT_GETSTATE` under `ProtectSystem=strict`.
+
+### Changed
+- `apply_temperature` no longer calls `drmSetMaster`. The C daemon never
+  did either, and grabbing the master while the compositor holds it is
+  pointless; `SETGAMMA` succeeds whenever the compositor has released
+  the master (TTY switch) or we hold raw rw access on the right card.
+- 30 s failure backoff after a failed apply, reset on success or VT
+  change. Stops the log filling up every `CHECK_INTERVAL` when the
+  compositor still owns master.
+- Demoted the `try_become_master` failure log from `warn` to `debug`.
+  The CLI tool still calls it best-effort; the warning was noise on
+  every COSMIC session.
+
 ## [2.0.0] - 2026-05-21
 
 ### Added
@@ -96,7 +123,8 @@ section heading format strict: `## [X.Y.Z] - YYYY-MM-DD`.
   DE, working around missing `wlr-gamma-control-unstable-v1` protocol
   support on the Pop!\_OS COSMIC compositor (`7cb2c59`).
 
-[Unreleased]: https://github.com/jjo/drm-colortemp/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/jjo/drm-colortemp/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/jjo/drm-colortemp/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/jjo/drm-colortemp/compare/v1.4.0...v2.0.0
 [1.4.0]: https://github.com/jjo/drm-colortemp/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/jjo/drm-colortemp/compare/v1.2.0...v1.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "drm-colortemp-rs"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drm-colortemp-rs"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.70"
 

--- a/packaging/aur/.SRCINFO-rust
+++ b/packaging/aur/.SRCINFO-rust
@@ -1,6 +1,6 @@
 pkgbase = drm-colortemp
 	pkgdesc = DRM color temperature control for COSMIC DE (Rust rewrite, wlr-gamma-control workaround)
-	pkgver = 2.0.0
+	pkgver = 2.0.1
 	pkgrel = 1
 	url = https://github.com/jjo/drm-colortemp
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = drm-colortemp
 	depends = gcc-libs
 	optdepends = libnotify: desktop notifications
 	backup = etc/default/drm-colortemp.conf
-	source = drm-colortemp-2.0.0.tar.gz::https://github.com/jjo/drm-colortemp/archive/refs/tags/v2.0.0.tar.gz
+	source = drm-colortemp-2.0.1.tar.gz::https://github.com/jjo/drm-colortemp/archive/refs/tags/v2.0.1.tar.gz
 	sha256sums = SKIP
 
 pkgname = drm-colortemp

--- a/packaging/aur/PKGBUILD-rust
+++ b/packaging/aur/PKGBUILD-rust
@@ -4,7 +4,7 @@
 # Builds the single `drm-colortemp` binary from `Cargo.toml` and ships the
 # v2.x systemd unit + notifier scripts.
 pkgname=drm-colortemp
-pkgver=2.0.0
+pkgver=2.0.1
 pkgrel=1
 pkgdesc="DRM color temperature control for COSMIC DE (Rust rewrite, wlr-gamma-control workaround)"
 arch=('x86_64')

--- a/scripts/drm-colortemp.service
+++ b/scripts/drm-colortemp.service
@@ -6,7 +6,7 @@ Wants=display-manager.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/drm-colortemp --daemon
+ExecStart=/usr/bin/drm-colortemp --daemon
 Restart=on-failure
 RestartSec=5s
 Environment=RUST_LOG=info
@@ -20,9 +20,13 @@ ProtectHome=true
 ReadOnlyPaths=/etc/default/drm-colortemp.conf
 PrivateTmp=true
 
-# Allow DRM access
-DeviceAllow=/dev/dri/card0 rw
-DeviceAllow=/dev/dri/renderD128 rw
+# Allow all DRM devices. Hard-coding card0 breaks on machines where the
+# active GPU is card1+ (e.g. iGPU at /dev/dri/card1 with EVDI virtual cards
+# at card0/card2). char-drm covers every /dev/dri/* including future renderD*.
+DeviceAllow=char-drm rw
+# Required for VT_GETSTATE (active VT detection)
+DeviceAllow=/dev/tty0 r
+DeviceAllow=/dev/console r
 
 [Install]
 WantedBy=multi-user.target

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -70,8 +70,9 @@ fn apply_temperature(config: &Config, temp: u32) -> Result<(), &'static str> {
                 continue;
             }
         };
-        // Compositor may already own master; we keep going either way.
-        device::try_become_master(&dev);
+        // Don't grab SET_MASTER. C daemon doesn't; SETGAMMA works as long as
+        // the compositor has released the master (e.g. on TTY switch) or we
+        // hold raw rw access to the right card.
 
         let res = match drm::get_resources(dev.fd()) {
             Ok(r) => r,
@@ -149,6 +150,10 @@ pub fn run(config_path: &str) -> Result<(), DaemonError> {
     let mut last_check = Instant::now() - check_interval;
     let mut last_applied_temp: Option<u32> = None;
     let mut prev_vt: Option<Option<i32>> = None;
+    // Backoff when SET_GAMMA keeps failing (compositor owns DRM master).
+    // Reset on success or VT change.
+    let failure_backoff = Duration::from_secs(30);
+    let mut last_failure: Option<Instant> = None;
 
     while !STOP_REQUESTED.load(Ordering::Relaxed) {
         // SIGHUP → explicit reload.
@@ -184,20 +189,38 @@ pub fn run(config_path: &str) -> Result<(), DaemonError> {
         let active_vt = vt::active_vt();
         let target_temp = choose_target_temp(&config, active_vt);
 
-        if prev_vt != Some(active_vt) {
+        let vt_changed = prev_vt != Some(active_vt);
+        if vt_changed {
             if let Some(prev) = prev_vt {
                 debug!("VT changed: {prev:?} -> {active_vt:?}");
             }
             prev_vt = Some(active_vt);
+            // VT switch is the canonical recovery point (compositor may have
+            // released master). Clear backoff so the next attempt fires now.
+            last_failure = None;
         }
 
+        let backoff_ok = last_failure
+            .map(|t| now.duration_since(t) >= failure_backoff)
+            .unwrap_or(true);
         let should_apply = last_applied_temp != Some(target_temp)
-            && now.duration_since(last_check) >= Duration::from_millis(200);
+            && now.duration_since(last_check) >= Duration::from_millis(200)
+            && backoff_ok;
         if should_apply {
             info!("Applying {target_temp}K (VT={:?})", active_vt);
             match apply_temperature(&config, target_temp) {
-                Ok(()) => last_applied_temp = Some(target_temp),
-                Err(e) => error!("Apply {target_temp}K failed: {e}"),
+                Ok(()) => {
+                    last_applied_temp = Some(target_temp);
+                    last_failure = None;
+                }
+                Err(e) => {
+                    if last_failure.is_none() {
+                        error!("Apply {target_temp}K failed: {e} (backing off {failure_backoff:?})");
+                    } else {
+                        debug!("Apply {target_temp}K still failing: {e}");
+                    }
+                    last_failure = Some(now);
+                }
             }
             last_check = now;
         }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,7 @@
 //! DRM device open/auto-detect/access checks.
 
 use crate::drm;
-use log::{debug, warn};
+use log::debug;
 use std::ffi::CString;
 use std::os::unix::io::RawFd;
 use std::path::Path;
@@ -140,12 +140,13 @@ fn open_raw(path: &str) -> Result<DrmDevice, DeviceError> {
     })
 }
 
-/// Best-effort DRM master grab. Logs a warning on failure and continues.
+/// Best-effort DRM master grab. Logs at debug on failure and continues.
+/// Used by the one-shot CLI tool; the daemon skips this and relies on the
+/// compositor releasing the master on TTY switch.
 pub fn try_become_master(dev: &DrmDevice) {
     if let Err(e) = drm::try_set_master(dev.fd()) {
-        warn!(
-            "Could not become DRM master on {} ({}): compositor likely running. \
-             Run from a TTY (Ctrl+Alt+F3) or stop the compositor if gamma changes fail.",
+        debug!(
+            "Could not become DRM master on {} ({}): compositor likely running.",
             dev.path(),
             e
         );


### PR DESCRIPTION
## Summary

- Daemon failed silently with "no CRTCs accepted the gamma change" on machines where the active GPU isn't `card0` (e.g. T480s: `card0`/`card2` are EVDI virtual, `card1` is the real Intel iGPU).
- Root cause: `DeviceAllow=/dev/dri/card0 rw` in the systemd unit blocked the cgroup device filter from opening `card1`. Auto-detect fell back to `card0`, every CRTC reported `mode_valid=0`, skip path was at `debug!` level, so the failure looked silent.
- Fix: `DeviceAllow=char-drm rw` — covers every `/dev/dri/card*` and `/dev/dri/renderD*`.

## Other changes (940cb45)

- `apply_temperature` no longer calls `drmSetMaster`. C daemon doesn't either; SETGAMMA works once the compositor releases master (TTY switch) or we hold raw rw on the right card.
- 30s failure backoff after a failed apply, reset on success or VT change. Stops the log filling up every check_interval when the compositor still holds master.
- Demote `try_become_master` failure log from `warn` to `debug` (CLI tool path still calls it best-effort; warning was noise on every COSMIC session).

Also aligns `ExecStart` with the `.deb` install path (`/usr/bin`) and adds `DeviceAllow` entries for `/dev/tty0` + `/dev/console` (needed by `VT_GETSTATE` under `ProtectSystem=strict`).

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` — 34 pass
- [x] Reproduced on T480s: rebuilt + reinstalled service, restart daemon, switched VT3/VT4/VT5, gamma applies, log shows "Applied" without errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added failure backoff for temperature application to avoid rapid retries; backoff resets on success or VT change
  * Temperature adjustment no longer requires DRM master status

* **Chores**
  * Updated service install path and broadened device access permissions for better hardware compatibility
  * Downgraded a master-acquisition log from warn to debug

* **Documentation**
  * Bumped release to 2.0.1 and updated changelog and packaging metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jjo/drm-colortemp/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->